### PR TITLE
Update README.md to use addRoutes instead of registerRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ the following order:
 
 ### How Chrome implements this?
 
-The Google Chrome team starts the Oritin Trial from M116, and the implementation has slightly been chagned from M117.
+The Google Chrome team starts the Origin Trial from M116, and the implementation has slightly been changed from M117.
 It has been explained in [a separate document](update-from-chrome-m116.md).
 
 There was `registerRouter()`.  For ease of understanding the latest routes, it can be called once.  However, it made it difficult for

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ the original proposal.  It is natural evolution to use `URLPattern` instead of U
 
 *   Introduce `addRoutes()` method, and won’t provide `add()` or `get()` methods.
     *   `addRoutes()` method sets ServiceWorker routes with specified routes.
-        To allow third party services to use the API, the method can be called multile times.
+        To allow third party services to use the API, the method can be called multiple times.
 *   URL related conditions are merged into `URLPattern`.
 
 ### How does it work with [empty fetch listeners](https://github.com/yoshisatoyanagisawa/service-worker-skip-no-op-fetch-handler)?

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ dictionary RouterCondition {
 enum RouterSourceEnum { "network" };
 ```
 
-Note that `registerRouter`, which can be called once, has been deprecated.  To allow third-party services to add routes,
-the method has been renamed to `addRoutes` and can be called multiple times.  The rules are evalauted sequentially with
-added order.  It means that if `addRoutes` are called multiple times, rules added ealier will be evaluated ealier.
+Note that the rules are evalauted sequentially with added order.  It means that if `addRoutes` is called multiple times,
+rules added ealier will be evaluated ealier.
 
 ### Examples
 
@@ -148,8 +147,9 @@ For local testing, you can enable the feature by flipping the `Service Worker St
 ### How is the proposal different from Jake’s original proposal?
 
 We propose `addRoutes()` to set routes with specified routes instead of `add()` and `get()`.  Unlike `add()` or `get()`,
-`addRoutes()` can take a list of rules in addition to a single rule.  It can be called multiple times to be used by third party services
-to register their routes.  Web developers need to use the browser mechanisms like devtools to check the latest router rules.
+`addRoutes()` can take a list of rules in addition to a single rule.  It can be called multiple times in case if needed
+(e.g. imported third-party service worker script already added some routes).  Web developers need to use the browser mechanisms like
+devtools to check the latest router rules.
 `addRoutes` is a part of the `install` event [^1].
 Since `addRoutes()` is only the method to set the router rules, we put it as a part of the `install` event.
 When the `install` listener is executed, no routes are set.  Web developers can call `addRoutes()` to set
@@ -195,3 +195,6 @@ the following order:
 
 The Google Chrome team starts the Oritin Trial from M116, and the implementation has slightly been chagned from M117.
 It has been explained in [a separate document](update-from-chrome-m116.md).
+
+There was `registerRouter`.  For ease of understanding the latest routes, it can be called once.  However, it made it difficult for
+the third-party services to add routes.  To solve the situation, the method has been renamed to `addRoutes` and can be called multiple times.  

--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ The Google Chrome team starts the Oritin Trial from M116, and the implementation
 It has been explained in [a separate document](update-from-chrome-m116.md).
 
 There was `registerRouter()`.  For ease of understanding the latest routes, it can be called once.  However, it made it difficult for
-the third-party services to add routes.  To solve the situation, the method has been renamed to `addRoutes` and can be called multiple times.  
+the third-party services to add routes.  To solve the situation, the method has been renamed to `addRoutes()` and can be called multiple times.  

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ allow evolution to [the full picture](final-form.md) in the future.
 ```webidl
 // This follows Jake's proposal.  Router is implemented in the InstallEvent.
 interface InstallEvent : ExtendableEvent {
-  // `addRoutes` is used to define static routes.
+  // `addRoutes()` is used to define static routes.
   // Not matching all rules means fallback to the regular process.
   // i.e. fetch handler.
   // Promise is rejected for invalid `rules` e.g. syntax error.
@@ -92,7 +92,7 @@ dictionary RouterCondition {
 enum RouterSourceEnum { "network" };
 ```
 
-Note that the rules are evalauted sequentially with added order.  It means that if `addRoutes` is called multiple times,
+Note that the rules are evalauted sequentially with added order.  It means that if `addRoutes()` is called multiple times,
 rules added ealier will be evaluated ealier.
 
 ### Examples
@@ -150,7 +150,7 @@ We propose `addRoutes()` to set routes with specified routes instead of `add()` 
 `addRoutes()` can take a list of rules in addition to a single rule.  It can be called multiple times in case if needed
 (e.g. imported third-party service worker script already added some routes).  Web developers need to use the browser mechanisms like
 devtools to check the latest router rules.
-`addRoutes` is a part of the `install` event [^1].
+`addRoutes()` is a part of the `install` event [^1].
 Since `addRoutes()` is only the method to set the router rules, we put it as a part of the `install` event.
 When the `install` listener is executed, no routes are set.  Web developers can call `addRoutes()` to set
 routes at that time.
@@ -196,5 +196,5 @@ the following order:
 The Google Chrome team starts the Oritin Trial from M116, and the implementation has slightly been chagned from M117.
 It has been explained in [a separate document](update-from-chrome-m116.md).
 
-There was `registerRouter`.  For ease of understanding the latest routes, it can be called once.  However, it made it difficult for
+There was `registerRouter()`.  For ease of understanding the latest routes, it can be called once.  However, it made it difficult for
 the third-party services to add routes.  To solve the situation, the method has been renamed to `addRoutes` and can be called multiple times.  


### PR DESCRIPTION
To reflect the discussion in https://github.com/WICG/service-worker-static-routing-api/issues/10, the API name has been changed from `registerRouter` to `addRoutes`. The README.md has also been updated to clarify that the API can be called multiple times.