### PR TITLE
Update RunningStatusEnum

### DIFF
--- a/final-form.md
+++ b/final-form.md
@@ -48,7 +48,7 @@ dictionary RouterRunningStatusCondition : RouterCondition {
   RunningStatusEnum runningStatus;
 };
 
-enum RunningStatusEnum { "running", "stopped" }
+enum RunningStatusEnum { "running", "not-running" }
 
 dictionary RouterAndCondition : RouterCondition {
   sequence<RouterCondition> and;


### PR DESCRIPTION
RunningStatusEnum: "stopped" is confusing, because in the browser there are more service worker running status, which is not described in the two enum values. In chromium, SW running status can be "starting", or "stopping". So, changing "stopped" to "not-running" covers all cases.