### PR TITLE
Add a cdn example case.

### DIFF
--- a/update-from-chrome-ot.md
+++ b/update-from-chrome-ot.md
@@ -86,6 +86,15 @@ Use cache storage named “pictures” for files whose name ends with “.png”
 }
 ```
 
+e.g.
+Directory fetch from the network for subresources served via a content delivery network (CDN) named "cdn.example.com".
+```js
+{
+  condition: {urlPattern: new URLPattern({hostname: "cdn.example.com"})},
+  source: "network"
+}
+```
+
 ## DevTools support
 
 ### Show registered router rules


### PR DESCRIPTION
While seeing the examples, I felt it nice to have an example that can be implemented with the new `urlPattern` condition.  Let me add that.