### PR TITLE
Remove sentence on Spectre to avoid confusion

### DIFF
--- a/resource-timing-api.md
+++ b/resource-timing-api.md
@@ -402,9 +402,7 @@ its security considerations.
 
 As covered in the resource timing specification, the main security concern is
 the use of high resolution timers. The timing field of the resource timing is
-defined to use high resolution timers. However, if malicious actors gain access
-to high resolution timers, they could use the exposed fields as a part of
-Spectre attack to inspect any memory accesses. In addition, this could expose
+defined to use high resolution timers. In addition, this could expose
 timing information about how the other origins loaded as well, leading to
 inferring information about the user's activity across origins.
 


### PR DESCRIPTION
This PR removes the sentence mentioning Spectre from the explainer for resource timing API to avoid confusion.